### PR TITLE
Possible NPE fixed.

### DIFF
--- a/src/main/java/info/bluefloyd/jenkins/IssueUpdatesBuilder.java
+++ b/src/main/java/info/bluefloyd/jenkins/IssueUpdatesBuilder.java
@@ -352,7 +352,7 @@ public class IssueUpdatesBuilder extends Builder {
 
 	private void updateIssueField(SOAPClient client, SOAPSession session, RemoteIssue issue, PrintStream logger) {
 		boolean updateFieldSuccessful = false;
-		if (!customFieldId.trim().isEmpty()) {
+		if ( customFieldId != null && !customFieldId.trim().isEmpty()) {
 			updateFieldSuccessful = client.updateIssueField(session, issue.getKey(), customFieldId, realFieldValue);
 			if (!updateFieldSuccessful) {
 				logger.println("Could not update field " + customFieldId + "for issue " + issue.getKey());


### PR DESCRIPTION
If the customerFieldId is null, function updateIssueField will produce a
NPE. This is also a compatibility problem in the case of upgrading from
a previous version.