### PR TITLE
JENKINS-28140 Allow *append* state for custom field updater

### DIFF
--- a/src/main/java/info/bluefloyd/jenkins/SOAPClient.java
+++ b/src/main/java/info/bluefloyd/jenkins/SOAPClient.java
@@ -8,17 +8,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import com.atlassian.jira.rpc.soap.client.*;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
-import com.atlassian.jira.rpc.soap.client.JiraSoapService;
-import com.atlassian.jira.rpc.soap.client.RemoteAuthenticationException;
-import com.atlassian.jira.rpc.soap.client.RemoteComment;
-import com.atlassian.jira.rpc.soap.client.RemoteFieldValue;
-import com.atlassian.jira.rpc.soap.client.RemoteIssue;
-import com.atlassian.jira.rpc.soap.client.RemoteNamedObject;
-import com.atlassian.jira.rpc.soap.client.RemotePermissionException;
-import com.atlassian.jira.rpc.soap.client.RemoteVersion;
 
 /**
  * Simple client used to make calls to Jira via SOAP.
@@ -123,7 +115,7 @@ public class SOAPClient {
 		JiraSoapService jiraSoapService = session.getJiraSoapService();
 		RemoteComment comment = new RemoteComment();
 		comment.setBody(commentText);
-		String errorMessage = "Error adding  comment to issue: " + issueKey;
+		String errorMessage = "Error adding comment to issue: " + issueKey;
 		boolean commentAdded = false;
 		try {
 			jiraSoapService.addComment(token, issueKey, comment);
@@ -141,7 +133,7 @@ public class SOAPClient {
 	}
 	
 	/**
-	 * Returns all versions defined for specified peoject.
+	 * Returns all versions defined for specified project.
 	 * @param session
 	 * @param projectKey	project key
 	 * @return
@@ -165,6 +157,29 @@ public class SOAPClient {
 	}
 
 	/**
+	 * Returns all custom fields defined in Jira instance
+	 * @param session
+	 * @return
+	 */
+	public List<RemoteField> getCustomFields( SOAPSession session ) {
+		String token = session.getAuthenticationToken();
+		JiraSoapService soap = session.getJiraSoapService();
+
+		List<RemoteField> customFields = new ArrayList<RemoteField>();
+		try	{
+			RemoteField[] remoteCustomFields = soap.getCustomFields(token);
+			if ( remoteCustomFields != null ) {
+				for( RemoteField customField : remoteCustomFields ) {
+					customFields.add( customField );
+				}
+			}
+		} catch ( RemoteException e ) {
+			LOGGER.error( "Error getting list of custom fields for Jira instance.", e);
+		}
+		return customFields;
+	}
+
+	/**
 	 * Updates fixedVersions of the specified jira issue.
 	 * @param session
 	 * @param issue
@@ -174,7 +189,7 @@ public class SOAPClient {
 	 */
 	public boolean updateFixedVersions( SOAPSession session, final RemoteIssue issue, Collection<String> finalVersionIds )
 	{
-		return updateIssueField(session, issue.getKey(), "fixVersions", finalVersionIds.toArray( new String[]{} ));
+		return updateIssueField(session, issue.getKey(), "fixVersions", finalVersionIds.toArray( new String[finalVersionIds.size()] ));
 	}
 
 	public boolean updateIssueField(SOAPSession session, final String issueKey, String fieldId, String fieldValue)

--- a/src/main/java/info/bluefloyd/jenkins/SOAPSession.java
+++ b/src/main/java/info/bluefloyd/jenkins/SOAPSession.java
@@ -34,7 +34,7 @@ public class SOAPSession {
 				LOGGER.info("SOAP Session service endpoint at " + webServicePort.toExternalForm());
 			}
 		} catch (ServiceException e) {
-			throw new RuntimeException("ServiceException during SOAPClient contruction", e);
+			throw new RuntimeException("ServiceException during SOAPClient construction", e);
 		}
 	}
 
@@ -43,7 +43,7 @@ public class SOAPSession {
 	}
 
 	public void connect(String userName, String password) throws RemoteException {
-		LOGGER.info("Connnecting via SOAP as : " + userName);
+		LOGGER.info("Connecting via SOAP as : " + userName);
 		token = getJiraSoapService().login(userName, password);
 		LOGGER.info("Connected");
 	}

--- a/src/main/resources/info/bluefloyd/jenkins/IssueUpdatesBuilder/config.jelly
+++ b/src/main/resources/info/bluefloyd/jenkins/IssueUpdatesBuilder/config.jelly
@@ -29,14 +29,18 @@
     <f:textbox />
   </f:entry>
 
-  <f:entry title="Jira custom field to be edited" field="customFieldId">
-    <f:textbox />
+  <f:entry title="Jira custom field to be updated" field="customFieldId">
+    <f:select />
   </f:entry>
 
   <f:entry title="Jira custom field value" field="customFieldValue">
     <f:textbox />
   </f:entry>
-  
+
+  <f:entry title="Jira custom field update mode" field="customFieldUpdateMode">
+    <f:select />
+  </f:entry>
+
   <f:entry title="Remove existing fixed versions first" field="resettingFixedVersions">
     <f:checkbox />
   </f:entry>

--- a/src/main/resources/info/bluefloyd/jenkins/IssueUpdatesBuilder/help-customFieldId.html
+++ b/src/main/resources/info/bluefloyd/jenkins/IssueUpdatesBuilder/help-customFieldId.html
@@ -1,5 +1,5 @@
 <div>
-	The key of the custom field.
+	The key of the custom field. Possible values will auto-populate from Jira, if available.
 	Example:<br>
 	<em>customfield_10862</em><br>
 </div>

--- a/src/main/resources/info/bluefloyd/jenkins/IssueUpdatesBuilder/help-customFieldUpdateMode.html
+++ b/src/main/resources/info/bluefloyd/jenkins/IssueUpdatesBuilder/help-customFieldUpdateMode.html
@@ -1,0 +1,4 @@
+<div>
+    Whether the custom field update should REPLACE, or APPEND the existing field value<br>
+    APPEND currently only works for multi-value custom fields (label, fix version, etc, style of field)<br>
+</div>

--- a/src/test/java/info/bluefloyd/jenkins/IssueUpdatesBuilderTest.java
+++ b/src/test/java/info/bluefloyd/jenkins/IssueUpdatesBuilderTest.java
@@ -19,6 +19,7 @@ public class IssueUpdatesBuilderTest
 		String comment = "$CMT _$$CMT $SQL_var $ActionName $VERSION2";
 		String fieldId = "customfield_10862";
 		String fieldValue = "$SQL_var ver $VERSION2";
+		String fieldUpdateMode = IssueUpdatesBuilder.CUSTOM_FIELD_REPLACE;
 		String workflowActionName ="  $ActionName $ ActionName";
 		String fixedVersions = "v1,$VERSION2,$VERSIONS";
 		
@@ -29,7 +30,7 @@ public class IssueUpdatesBuilderTest
 		vars.put( "VERSION2", "v2" );
 		vars.put( "VERSIONS", "v3,v4,v5" );
 		
-		IssueUpdatesBuilder builder = new IssueUpdatesBuilder( "soapUrl", "userName", "password", jql, workflowActionName, comment, fieldId, fieldValue, true, fixedVersions, true, true );
+		IssueUpdatesBuilder builder = new IssueUpdatesBuilder( "soapUrl", "userName", "password", jql, workflowActionName, comment, fieldId, fieldValue, fieldUpdateMode, true, fixedVersions, true, true );
 		Assert.assertEquals( "var1 var1 $var1", builder.substituteEnvVar( "$VAR $VAR $$VAR", "VAR", "var1"  ) );
 
 		builder.substituteEnvVars( vars );


### PR DESCRIPTION
Extended custom field functionality to populate the custom fields from JIRA (rather than manual entry. backwards compatible)
Added ability to choose whether the custom field update should REPLACE, APPEND existing field data
Attempted to add PREPEND functionality, but that couldn't be achieved with current RPC service.
Fixed some typos