### PR TITLE
Enable Plugin to create not Existing FixVersions

### DIFF
--- a/src/main/java/info/bluefloyd/jenkins/IssueUpdatesBuilder.java
+++ b/src/main/java/info/bluefloyd/jenkins/IssueUpdatesBuilder.java
@@ -71,6 +71,7 @@ public class IssueUpdatesBuilder extends Builder {
 	private String realFieldValue;
 	
 	private boolean resettingFixedVersions;
+	private boolean createNonExistingFixedVersions;
 	private String fixedVersions;
 	private boolean failIfJqlFails;
 	private boolean failIfNoIssuesReturned;
@@ -85,7 +86,8 @@ public class IssueUpdatesBuilder extends Builder {
 	@DataBoundConstructor
 	public IssueUpdatesBuilder(String soapUrl, String userName, String password, String jql, String workflowActionName,
 							   String comment, String customFieldId, String customFieldValue, boolean resettingFixedVersions,
-							   String fixedVersions, boolean failIfJqlFails, boolean failIfNoIssuesReturned) {
+							   boolean createNonExistingFixedVersions, String fixedVersions, boolean failIfJqlFails, 
+							   boolean failIfNoIssuesReturned) {
 		this.soapUrl = soapUrl;
 		this.userName = userName;
 		this.password = password;
@@ -95,6 +97,7 @@ public class IssueUpdatesBuilder extends Builder {
 		this.customFieldId = customFieldId;
 		this.customFieldValue = customFieldValue;
 		this.resettingFixedVersions = resettingFixedVersions;
+		this.createNonExistingFixedVersions = createNonExistingFixedVersions;
 		this.fixedVersions = fixedVersions;
 		this.failIfJqlFails = failIfJqlFails;
 		this.failIfNoIssuesReturned = failIfNoIssuesReturned;
@@ -319,7 +322,14 @@ public class IssueUpdatesBuilder extends Builder {
 			{
 				final String id = map.get( name.trim() );
 				if ( id == null ) {
-					logger.println( "Cannot find version " + name + " in project " + projectKey );
+					if(createNonExistingFixedVersions) {
+						logger.println( "Creating Non-existent version " + name + " in project " + projectKey );	
+						RemoteVersion newVersion = client.addVersion(session, projectKey, name);
+						ids.add(newVersion.getId());	
+					}
+					else {
+						logger.println( "Cannot find version " + name + " in project " + projectKey );	
+					}
 				} else {
 					ids.add( id );
 				}

--- a/src/main/java/info/bluefloyd/jenkins/SOAPClient.java
+++ b/src/main/java/info/bluefloyd/jenkins/SOAPClient.java
@@ -140,6 +140,31 @@ public class SOAPClient {
 		return commentAdded;
 	}
 	
+
+	/**
+	 * Add a Version to the specified peoject.
+	 * @param session
+	 * @param projectKey	project key
+	 * @param version       The version to be created
+	 * @return
+	 */
+	public RemoteVersion addVersion( SOAPSession session, String projectKey, String version ) {
+		String token = session.getAuthenticationToken();
+		JiraSoapService soap = session.getJiraSoapService();
+
+		RemoteVersion newVersion = new RemoteVersion();
+		newVersion.setName(version);
+
+		try	{
+			return soap.addVersion(token, projectKey, newVersion);
+		} catch ( RemoteException e ) {
+			LOGGER.error( "Error creating version " + version + " for project " + projectKey, e);
+		}
+
+		return newVersion;
+	}
+
+
 	/**
 	 * Returns all versions defined for specified peoject.
 	 * @param session

--- a/src/main/resources/info/bluefloyd/jenkins/IssueUpdatesBuilder/config.jelly
+++ b/src/main/resources/info/bluefloyd/jenkins/IssueUpdatesBuilder/config.jelly
@@ -41,6 +41,10 @@
     <f:checkbox />
   </f:entry>
   
+  <f:entry title="Create Versions if they do not exist" field="createNonExistingFixedVersions">
+    <f:checkbox />
+  </f:entry>
+
   <f:entry title="Fixed versions to be added (delimited by comma)" field="fixedVersions">
     <f:textbox />
   </f:entry>

--- a/src/main/resources/info/bluefloyd/jenkins/IssueUpdatesBuilder/help-createNonExistingFixedVersions.html
+++ b/src/main/resources/info/bluefloyd/jenkins/IssueUpdatesBuilder/help-createNonExistingFixedVersions.html
@@ -1,0 +1,7 @@
+<div>
+	If is checked, the given fix versions will be created in the Projects before trying to add them to the Issues
+	otherwise only existing fix versions will be added to the issues. <br/>
+	
+	With this option checked, and "Fixed versions to be added" left empty will effectively remove all existing fixed versions of the 
+	issues.
+</div>

--- a/src/test/java/info/bluefloyd/jenkins/IssueUpdatesBuilderTest.java
+++ b/src/test/java/info/bluefloyd/jenkins/IssueUpdatesBuilderTest.java
@@ -29,7 +29,7 @@ public class IssueUpdatesBuilderTest
 		vars.put( "VERSION2", "v2" );
 		vars.put( "VERSIONS", "v3,v4,v5" );
 		
-		IssueUpdatesBuilder builder = new IssueUpdatesBuilder( "soapUrl", "userName", "password", jql, workflowActionName, comment, fieldId, fieldValue, true, fixedVersions, true, true );
+		IssueUpdatesBuilder builder = new IssueUpdatesBuilder( "soapUrl", "userName", "password", jql, workflowActionName, comment, fieldId, fieldValue, true, true, fixedVersions, true, true );
 		Assert.assertEquals( "var1 var1 $var1", builder.substituteEnvVar( "$VAR $VAR $$VAR", "VAR", "var1"  ) );
 
 		builder.substituteEnvVars( vars );


### PR DESCRIPTION
In my Continuous Deployment Pipeline, my Jenkins Manages the whole Versioning, therefore I do not want to create Versions by hand, my Jenkins should be Able to Also Create them in this Step if they do not exist.

I Added a Checkbox to turn on/off this behavior.