### PR TITLE
JENKINS-31755 Allow unknown properties in JIRA model

### DIFF
--- a/src/main/java/info/bluefloyd/jira/model/FieldSummary.java
+++ b/src/main/java/info/bluefloyd/jira/model/FieldSummary.java
@@ -1,5 +1,6 @@
 package info.bluefloyd.jira.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 
 /**
@@ -8,6 +9,7 @@ import java.util.List;
  * 
  * @author Ian Sparkes, Swisscom AG
  */
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class FieldSummary {
   private String summary;
   private List<VersionSummary> versions;

--- a/src/main/java/info/bluefloyd/jira/model/IssueSummary.java
+++ b/src/main/java/info/bluefloyd/jira/model/IssueSummary.java
@@ -1,11 +1,14 @@
 package info.bluefloyd.jira.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  * Issue Summary. Encapsulates the issue information we get back from the
  * "find issues" rest call.
  * 
  * @author Ian Sparkes, Swisscom AG
  */
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class IssueSummary {
   private String expand;
   private String id;

--- a/src/main/java/info/bluefloyd/jira/model/IssueSummaryList.java
+++ b/src/main/java/info/bluefloyd/jira/model/IssueSummaryList.java
@@ -1,5 +1,6 @@
 package info.bluefloyd.jira.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -8,6 +9,7 @@ import java.util.List;
  * 
  * @author Ian Sparkes, Swisscom AG
  */
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class IssueSummaryList {
 
   private String expand;

--- a/src/main/java/info/bluefloyd/jira/model/PossibleTransition.java
+++ b/src/main/java/info/bluefloyd/jira/model/PossibleTransition.java
@@ -1,5 +1,7 @@
 package info.bluefloyd.jira.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  * Holder class for possible transitions. These are per JIRA and status.
  * 
@@ -8,6 +10,7 @@ package info.bluefloyd.jira.model;
  * 
  * @author Ian Sparkes, Swisscom AG
  */
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class PossibleTransition {
   private String id;
   private String name;

--- a/src/main/java/info/bluefloyd/jira/model/TransitionList.java
+++ b/src/main/java/info/bluefloyd/jira/model/TransitionList.java
@@ -1,5 +1,6 @@
 package info.bluefloyd.jira.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 
 /**
@@ -9,6 +10,7 @@ import java.util.List;
  * 
  * @author Ian Sparkes, Swisscom AG
  */
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class TransitionList {
   private String expand;
   private List<PossibleTransition> transitions;

--- a/src/main/java/info/bluefloyd/jira/model/VersionSummary.java
+++ b/src/main/java/info/bluefloyd/jira/model/VersionSummary.java
@@ -5,10 +5,13 @@
  */
 package info.bluefloyd.jira.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  *
  * @author ian
  */
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class VersionSummary {
   private boolean archived;
   private String description;

--- a/src/test/java/info/bluefloyd/jenkins/ReleaseVersionTest.java
+++ b/src/test/java/info/bluefloyd/jenkins/ReleaseVersionTest.java
@@ -1,0 +1,71 @@
+package info.bluefloyd.jenkins;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import info.bluefloyd.jira.model.IssueSummaryList;
+import info.bluefloyd.jira.model.VersionSummary;
+import java.io.IOException;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test case for Issue
+ *
+ * https://issues.jenkins-ci.org/browse/JENKINS-31755
+ *
+ * @author ian
+ */
+public class ReleaseVersionTest {
+
+  /**
+   * JSON parsing fails when managed versions are used. Fixed by adding
+   * VersionSummary class to the model.
+   *
+   * @throws java.io.IOException
+   */
+  @Test
+  public void TestFieldSummaryWithVersions() throws IOException {
+
+    String issueSummaryRESTResult = "{\n"
+            + "   \"expand\":\"names,schema\",\n"
+            + "   \"startAt\":0,\n"
+            + "   \"maxResults\":1000,\n"
+            + "   \"total\":1,\n"
+            + "   \"issues\":[\n"
+            + "      {\n"
+            + "         \"expand\":\"operations,versionedRepresentations,editmeta,changelog,transitions,renderedFields\",\n"
+            + "         \"id\":\"289777\",\n"
+            + "         \"self\":\"https://tallyjira.tallysolutions.com/rest/api/2/issue/289777\",\n"
+            + "         \"key\":\"TE-25246\",\n"
+            + "         \"fields\":{\n"
+            + "            \"summary\":\"VAT Internal - TIN is not getting updated in Ledger even after incorrect TIN matches with Master.\",\n"
+            + "            \"versions\":[\n"
+            + "               {\n"
+            + "                  \"self\":\"https://tallyjira.tallysolutions.com/rest/api/2/version/12443\",\n"
+            + "                  \"id\":\"12443\",\n"
+            + "                  \"description\":\"Series A Release 5.0\",\n"
+            + "                  \"name\":\"Series A Release 5.0\",\n"
+            + "                  \"archived\":false,\n"
+            + "                  \"released\":true,\n"
+            + "                  \"releaseDate\":\"2015-08-03\"\n"
+            + "               }\n"
+            + "            ]\n"
+            + "         }\n"
+            + "      }\n"
+            + "   ]\n"
+            + "}";
+
+    ObjectMapper mapper = new ObjectMapper();
+    IssueSummaryList summaryList = mapper.readValue(issueSummaryRESTResult, IssueSummaryList.class);
+
+    assertNotNull(summaryList);
+    assertEquals(1, summaryList.getIssues().size());
+    assertEquals(1, summaryList.getIssues().get(0).getFields().getVersions().size());
+    VersionSummary version = summaryList.getIssues().get(0).getFields().getVersions().get(0);
+    assertFalse(version.isArchived());
+    assertTrue(version.isReleased());
+    assertEquals("12443", version.getId());
+  }
+}


### PR DESCRIPTION
We were being too restrictive with the JSON property handling: I added @JsonIgnoreProperties(ignoreUnknown=true) to the main model classes to increase the robustness of the plug in.

Now we should be able to deal with optional fields in the REST response without having to configure (and know) them all.  