### PR TITLE
add parametrized username and password

### DIFF
--- a/src/main/java/info/bluefloyd/jenkins/IssueUpdaterResultsRecorder.java
+++ b/src/main/java/info/bluefloyd/jenkins/IssueUpdaterResultsRecorder.java
@@ -64,6 +64,8 @@ public class IssueUpdaterResultsRecorder extends Recorder {
   private String realWorkflowActionName;
   private String realComment;
   private String realFieldValue;
+  private String realUserName;
+  private String realPassword;
 
   transient List<String> fixedVersionNames;
 
@@ -140,7 +142,7 @@ public class IssueUpdaterResultsRecorder extends Recorder {
     vars.putAll(build.getBuildVariables());
     substituteEnvVars(vars);
 
-    RESTClient client = new RESTClient(getRestAPIUrl(),getUserName(), getPassword(),logger);
+    RESTClient client = new RESTClient(getRestAPIUrl(),getRealUserName(), getRealPassword(),logger);
     
     // Find the list of issues we are interested in, maximum of 10000
     IssueSummaryList issueSummary = client.findIssuesByJQL(realJql);
@@ -318,6 +320,20 @@ public class IssueUpdaterResultsRecorder extends Recorder {
   public String getPassword() {
     return password;
   }
+  
+  /**
+   * @return the realUserName
+   */
+  public String getRealUserName() {
+    return realUserName;
+  }
+
+  /**
+   * @return the realPassword
+   */
+  public String getRealPassword() {
+    return realPassword;
+  }
 
   /**
    * @return the jql
@@ -373,6 +389,8 @@ public class IssueUpdaterResultsRecorder extends Recorder {
     realWorkflowActionName = workflowActionName;
     realComment = comment;
     realFieldValue = customFieldValue;
+    realUserName = userName;
+    realPassword = password;
     String expandedFixedVersions = fixedVersions == null ? "" : fixedVersions.trim();
     for (Map.Entry<String, String> entry : vars.entrySet()) {
       realJql = substituteEnvVar(realJql, entry.getKey(), entry.getValue());
@@ -380,6 +398,8 @@ public class IssueUpdaterResultsRecorder extends Recorder {
       realComment = substituteEnvVar(realComment, entry.getKey(), entry.getValue());
       realFieldValue = substituteEnvVar(realFieldValue, entry.getKey(), entry.getValue());
       expandedFixedVersions = substituteEnvVar(expandedFixedVersions, entry.getKey(), entry.getValue());
+	  realUserName = substituteEnvVar(realUserName, entry.getKey(), entry.getValue());
+	  realPassword = substituteEnvVar(realPassword, entry.getKey(), entry.getValue());
     }
     fixedVersionNames = Arrays.asList(expandedFixedVersions.trim().split(FIXED_VERSIONS_LIST_DELIMITER));
   }

--- a/src/main/java/info/bluefloyd/jenkins/IssueUpdatesBuilder.java
+++ b/src/main/java/info/bluefloyd/jenkins/IssueUpdatesBuilder.java
@@ -61,6 +61,8 @@ public class IssueUpdatesBuilder extends Builder {
 	private String realWorkflowActionName;
 	private String realComment;
 	private String realFieldValue;
+	private String realUserName;
+	private String realPassword;
 
 	private final boolean resettingFixedVersions;
 	private final boolean createNonExistingFixedVersions;
@@ -153,6 +155,14 @@ public class IssueUpdatesBuilder extends Builder {
 	public String getFixedVersions() {
 		return fixedVersions;
 	}
+	
+	public String getRealUserName() {
+		return realUserName;
+	}
+	
+	public String getRealPassword() {
+		return realPassword;
+	}
 
 	public boolean isResettingFixedVersions() {
 		return resettingFixedVersions;
@@ -186,7 +196,7 @@ public class IssueUpdatesBuilder extends Builder {
 		vars.putAll(build.getBuildVariables());
 		substituteEnvVars(vars);
 
-		RESTClient client = new RESTClient(getRestAPIUrl(),getUserName(), getPassword(),logger);
+		RESTClient client = new RESTClient(getRestAPIUrl(),getRealUserName(), getRealPassword(),logger);
 		client.setDebug(debug);
 
 		// Find the list of issues we are interested in, maximum of 10000
@@ -348,6 +358,8 @@ public class IssueUpdatesBuilder extends Builder {
 		realWorkflowActionName = workflowActionName;
 		realComment = comment;
 		realFieldValue = customFieldValue;
+		realUserName = userName;
+		realPassword = password;
 		String expandedFixedVersions = fixedVersions == null ? "" : fixedVersions.trim();
 		for (Map.Entry<String, String> entry : vars.entrySet()) {
 			realJql = substituteEnvVar(realJql, entry.getKey(), entry.getValue());
@@ -355,6 +367,8 @@ public class IssueUpdatesBuilder extends Builder {
 			realComment = substituteEnvVar(realComment, entry.getKey(), entry.getValue());
 			realFieldValue = substituteEnvVar(realFieldValue, entry.getKey(), entry.getValue());
 			expandedFixedVersions = substituteEnvVar(expandedFixedVersions, entry.getKey(), entry.getValue());
+			realUserName = substituteEnvVar(realUserName, entry.getKey(), entry.getValue());
+			realPassword = substituteEnvVar(realPassword, entry.getKey(), entry.getValue());
 		}
 		fixedVersionNames = Arrays.asList(expandedFixedVersions.trim().split(FIXED_VERSIONS_LIST_DELIMITER));
 	}


### PR DESCRIPTION
Problem:
I have several jobs which are using this plugin. When I want to change username/password for JIRA access I have to edit every job.

Solution:
Username/password fields should accept $VARIABLES (f.e. I can use 'Mask Password Plugin' and set password on global configuration page and change it only in one place).